### PR TITLE
feat: volume create, attach, show and delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/lxc/incus v0.7.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -61,5 +62,4 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/pkg/incus/client/client.go
+++ b/pkg/incus/client/client.go
@@ -4,10 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
+	"slices"
+	"sort"
+	"strings"
 	"time"
+
+	"gopkg.in/yaml.v2"
 
 	incus "github.com/lxc/incus/client"
 	"github.com/lxc/incus/shared/api"
@@ -325,4 +331,119 @@ func (i *IncusClient) DeleteInstance(instance string) error {
 	}
 
 	return op.Wait()
+}
+
+func (i *IncusClient) CreateStorageVolume(pool string, name string, args map[string]string) error {
+	// Parse the input
+	volName, volType := parseVolume("custom", name)
+
+	var volumePut api.StorageVolumePut
+
+	// Create the storage volume entry
+	vol := api.StorageVolumesPost{
+		Name:             volName,
+		Type:             volType,
+		ContentType:      "filesystem",
+		StorageVolumePut: volumePut,
+	}
+
+	if volumePut.Config == nil {
+		vol.Config = map[string]string{}
+	}
+
+	for k, v := range args {
+		vol.Config[k] = v
+	}
+
+	err := i.client.CreateStoragePoolVolume(pool, vol)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *IncusClient) AttachStorageVolume(pool string, name string, service string, mountpoint string) error {
+	instance, etag, err := i.client.GetInstance(service)
+	if err != nil {
+		return err
+	}
+
+	volName, volType := parseVolume("custom", name)
+	if volType != "custom" {
+		return fmt.Errorf("Only \"custom\" volumes can be attached to instances")
+	}
+
+	// Prepare the instance's device entry
+	dev := map[string]string{
+		"type":   "disk",
+		"pool":   pool,
+		"source": volName,
+		"path":   mountpoint,
+	}
+
+	// Check if device exists
+	_, ok := instance.Devices[name]
+	if ok {
+		return fmt.Errorf("Device already exists: %s", name)
+	}
+	instance.Devices[name] = dev
+
+	op, err := i.client.UpdateInstance(service, instance.Writable(), etag)
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
+}
+
+func (i *IncusClient) ShowStorageVolume(pool string, name string) error {
+	// Parse the input
+	volName, volType := parseVolume("custom", name)
+
+	// Get the storage volume entry
+	vol, _, err := i.client.GetStoragePoolVolume(pool, volType, volName)
+	if err != nil {
+		// Give more context on missing volumes.
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			if volType == "custom" {
+				return fmt.Errorf("Storage pool volume \"%s/%s\" not found. Try virtual-machine or container for type", volType, volName)
+			}
+
+			return fmt.Errorf("Storage pool volume \"%s/%s\" not found", volType, volName)
+		}
+
+		return err
+	}
+
+	sort.Strings(vol.UsedBy)
+
+	data, err := yaml.Marshal(&vol)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s", data)
+
+	return nil
+}
+
+func (i *IncusClient) DeleteStoragePoolVolume(pool string, name string) error {
+	volName, volType := parseVolume("custom", name)
+
+	if err := i.client.DeleteStoragePoolVolume(pool, volType, volName); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseVolume(defaultType string, name string) (string, string) {
+	parsedName := strings.SplitN(name, "/", 2)
+	if len(parsedName) == 1 {
+		return parsedName[0], defaultType
+	} else if len(parsedName) == 2 && !slices.Contains([]string{"custom", "image", "container", "virtual-machine"}, parsedName[0]) {
+		return name, defaultType
+	}
+
+	return parsedName[1], parsedName[0]
 }

--- a/pkg/incus/client/client.go
+++ b/pkg/incus/client/client.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
-
 	incus "github.com/lxc/incus/client"
 	"github.com/lxc/incus/shared/api"
 )

--- a/pkg/incus/client/client.go
+++ b/pkg/incus/client/client.go
@@ -397,7 +397,7 @@ func (i *IncusClient) AttachStorageVolume(pool string, name string, service stri
 	return op.Wait()
 }
 
-func (i *IncusClient) ShowStorageVolume(pool string, name string) error {
+func (i *IncusClient) ShowStorageVolume(pool string, name string) (*api.StorageVolume, error) {
 	// Parse the input
 	volName, volType := parseVolume("custom", name)
 
@@ -407,25 +407,18 @@ func (i *IncusClient) ShowStorageVolume(pool string, name string) error {
 		// Give more context on missing volumes.
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			if volType == "custom" {
-				return fmt.Errorf("Storage pool volume \"%s/%s\" not found. Try virtual-machine or container for type", volType, volName)
+				return nil, fmt.Errorf("Storage pool volume \"%s/%s\" not found. Try virtual-machine or container for type", volType, volName)
 			}
 
-			return fmt.Errorf("Storage pool volume \"%s/%s\" not found", volType, volName)
+			return nil, fmt.Errorf("Storage pool volume \"%s/%s\" not found", volType, volName)
 		}
 
-		return err
+		return nil, err
 	}
 
 	sort.Strings(vol.UsedBy)
 
-	data, err := yaml.Marshal(&vol)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s", data)
-
-	return nil
+	return vol, nil
 }
 
 func (i *IncusClient) DeleteStoragePoolVolume(pool string, name string) error {


### PR DESCRIPTION
This PR addresses Issue [#5](https://github.com/bketelsen/incus-compose/issues/5) .
volume create, attach, show and delete implementations are moved from cli to incus API.
We discussed that 'volumes list' shall be moved from cli to api implementation, but the existing one is not using cli.
I also noticed that ShowVolumesForService method of Compose struct is not currently used anywhere and we can discuss what should be the best applicable use of it.