### PR TITLE
feat: support for existing or deleted instances, volumes, bind during up, start, down, stop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/lxc/incus/v6 v6.4.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -79,5 +78,5 @@ require (
 	golang.org/x/term v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -191,9 +191,12 @@ func (app *Compose) SetConfig(config *config.Config) {
 // Use reverse=true for starting services.
 // Use reverse=false for stopping services.
 func (app *Compose) Order(reverse bool) []string {
-	order, _ := graph.TopologicalSort(app.Dag)
-	if reverse {
-		slices.Reverse(order)
+	if app.Dag != nil {
+		order, _ := graph.TopologicalSort(app.Dag)
+		if reverse {
+			slices.Reverse(order)
+		}
+		return order
 	}
-	return order
+	return []string{}
 }

--- a/pkg/application/binds.go
+++ b/pkg/application/binds.go
@@ -33,6 +33,18 @@ func (app *Compose) CreateBindsForService(service string) error {
 			return err
 		}
 		client.WithProject(app.GetProject())
+
+		inst, _, err := client.GetInstance(service)
+		if err != nil {
+			return err
+		}
+
+		_, ok := inst.Devices[bindName]
+		if ok {
+			slog.Info("Device already exists", slog.String("name", bindName))
+			return nil
+		}
+
 		err = client.AddDevice(service, bindName, device)
 		if err != nil {
 			return err

--- a/pkg/application/commands.go
+++ b/pkg/application/commands.go
@@ -41,11 +41,7 @@ func (app *Compose) Up() error {
 
 		err = app.StartContainerForService(service, true)
 		if err != nil {
-			if strings.Contains(err.Error(), "already running") {
-				slog.Info("Instance already running", slog.String("instance", service))
-			} else {
-				return err
-			}
+			return err
 		}
 
 	}
@@ -57,11 +53,7 @@ func (app *Compose) Stop(stateful, force bool, timeout int) error {
 
 		err := app.StopContainerForService(service, stateful, force, timeout)
 		if err != nil {
-			if strings.Contains(err.Error(), "already stopped") {
-				slog.Info("Instance already stopped", slog.String("instance", service))
-			} else {
-				return err
-			}
+			return err
 		}
 
 	}
@@ -73,11 +65,7 @@ func (app *Compose) Down(force, volumes bool, timeout int) error {
 
 		err := app.StopContainerForService(service, false, force, timeout)
 		if err != nil {
-			if strings.Contains(err.Error(), "already stopped") {
-				slog.Info("Instance already stopped", slog.String("instance", service))
-			} else {
-				return err
-			}
+			return err
 		}
 		err = app.RemoveContainerForService(service)
 		if err != nil {
@@ -169,11 +157,7 @@ func (app *Compose) Start(wait bool) error {
 
 		err := app.StartContainerForService(service, wait)
 		if err != nil {
-			if strings.Contains(err.Error(), "already running") {
-				slog.Info("Instance already running", slog.String("instance", service))
-			} else {
-				return err
-			}
+			return err
 		}
 
 	}

--- a/pkg/application/containerdelete.go
+++ b/pkg/application/containerdelete.go
@@ -20,6 +20,11 @@ func (app *Compose) RemoveContainerForService(service string) error {
 		return err
 	}
 	client.WithProject(app.GetProject())
-	return client.DeleteInstance(service)
+
+	inst, _, _ := client.GetInstance(service)
+	if inst != nil && inst.Name == service {
+		return client.DeleteInstance(service)
+	}
+	return nil
 
 }

--- a/pkg/application/containerinit.go
+++ b/pkg/application/containerinit.go
@@ -169,6 +169,12 @@ func (app *Compose) InitContainerForService(service string) error {
 	}
 	client.WithProject(app.GetProject())
 
+	inst, _, _ := client.GetInstance(service)
+	if inst != nil && inst.Name == service {
+		slog.Info("Instance found", slog.String("instance", service))
+		return nil
+	}
+
 	var instancePost api.InstancesPost
 	var devicesMap map[string]map[string]string
 	var configMap map[string]string

--- a/pkg/application/containerstart.go
+++ b/pkg/application/containerstart.go
@@ -34,9 +34,15 @@ func (app *Compose) StartContainerForService(service string, wait bool) error {
 		return err
 	}
 	client.WithProject(app.GetProject())
-	err = client.InstanceAction("start", service, false, false, -1)
-	if err != nil {
-		return err
+
+	inst, _, _ := client.GetInstance(service)
+	if inst != nil && inst.Name == service && inst.Status == "Running" {
+		slog.Info("Instance already running", slog.String("instance", service))
+	} else {
+		err = client.InstanceAction("start", service, false, false, -1)
+		if err != nil {
+			return err
+		}
 	}
 
 	if wait {

--- a/pkg/application/containerstop.go
+++ b/pkg/application/containerstop.go
@@ -20,6 +20,13 @@ func (app *Compose) StopContainerForService(service string, stateful, force bool
 		return err
 	}
 	client.WithProject(app.GetProject())
-	return client.InstanceAction("stop", service, stateful, force, timeout)
+
+	inst, _, _ := client.GetInstance(service)
+	if inst != nil && inst.Name == service && inst.Status == "Running" {
+		return client.InstanceAction("stop", service, stateful, force, timeout)
+	} else {
+		slog.Info("Instance already stopped", slog.String("instance", service))
+		return nil
+	}
 
 }

--- a/pkg/application/volumes.go
+++ b/pkg/application/volumes.go
@@ -164,6 +164,18 @@ func (app *Compose) attachVolume(name string, service string, vol Volume) error 
 	}
 	client.WithProject(app.GetProject())
 
+	instance, _, err := client.GetInstance(service)
+	if err != nil {
+		slog.Error(err.Error())
+	}
+
+	// Check if device exists
+	_, ok := instance.Devices[name]
+	if ok {
+		slog.Info("Device already exists", slog.String("volume", name))
+		return nil
+	}
+
 	if err := client.AttachStorageVolume(vol.Pool, name, service, vol.Mountpoint); err != nil {
 		slog.Error(err.Error())
 	}

--- a/pkg/application/volumes.go
+++ b/pkg/application/volumes.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/bketelsen/incus-compose/pkg/incus/client"
+	api "github.com/lxc/incus/v6/shared/api"
 )
 
 func (app *Compose) CreateVolumesForService(service string) error {
@@ -16,10 +17,18 @@ func (app *Compose) CreateVolumesForService(service string) error {
 	}
 	for volName, vol := range svc.Volumes {
 
-		slog.Debug("Volume", slog.String("name", vol.Name(app.Name, service, volName)), slog.String("pool", vol.Pool), slog.String("mountpoint", vol.Mountpoint))
-		err := app.createVolume(vol.Name(app.Name, service, volName), *vol, *vol.Snapshot)
-		if err != nil {
-			return err
+		completeName := vol.Name(app.Name, service, volName)
+		slog.Debug("Volume", slog.String("name", completeName), slog.String("pool", vol.Pool), slog.String("mountpoint", vol.Mountpoint))
+
+		existingVolume, _ := app.showVolume(completeName, *vol)
+
+		if existingVolume != nil && completeName == existingVolume.Name {
+			slog.Info("Volume found", slog.String("volume", completeName))
+		} else {
+			err := app.createVolume(completeName, *vol, *vol.Snapshot)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -49,11 +58,18 @@ func (app *Compose) DeleteVolumesForService(service string) error {
 	}
 	for volName, vol := range svc.Volumes {
 
-		slog.Debug("Volume", slog.String("name", vol.Name(app.Name, service, volName)), slog.String("pool", vol.Pool), slog.String("mountpoint", vol.Mountpoint))
+		completeName := vol.Name(app.Name, service, volName)
+		slog.Debug("Volume", slog.String("name", completeName), slog.String("pool", vol.Pool), slog.String("mountpoint", vol.Mountpoint))
 
-		err := app.deleteVolume(vol.Name(app.Name, service, volName), *vol)
-		if err != nil {
-			return err
+		existingVolume, _ := app.showVolume(completeName, *vol)
+
+		if existingVolume == nil || completeName != existingVolume.Name {
+			slog.Info("Volume not found", slog.String("volume", completeName))
+		} else {
+			err := app.deleteVolume(completeName, *vol)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -155,6 +171,28 @@ func (app *Compose) attachVolume(name string, service string, vol Volume) error 
 	return nil
 }
 
+func (app *Compose) showVolume(name string, vol Volume) (*api.StorageVolume, error) {
+	slog.Info("Checking volume", slog.String("volume", name))
+
+	args := []string{"storage", "volume", "show", vol.Pool, name}
+	args = append(args, "--project", app.GetProject())
+
+	slog.Debug("Incus Args", slog.String("args", fmt.Sprintf("%v", args)))
+
+	client, err := client.NewIncusClient()
+	if err != nil {
+		slog.Error(err.Error())
+	}
+	client.WithProject(app.GetProject())
+
+	v, err := client.ShowStorageVolume(vol.Pool, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
 func (app *Compose) ShowVolumesForService(service string) error {
 	slog.Info("Showing", slog.String("instance", service))
 	svc, ok := app.Services[service]
@@ -162,26 +200,11 @@ func (app *Compose) ShowVolumesForService(service string) error {
 		return fmt.Errorf("service %s not found", service)
 	}
 	for volName, vol := range svc.Volumes {
-		slog.Info("Showing volume", slog.String("volume", volName))
-
-		args := []string{"storage", "volume", "show", vol.Pool, vol.Name(app.Name, service, volName)}
-		args = append(args, "--project", app.GetProject())
-
-		slog.Debug("Incus Args", slog.String("args", fmt.Sprintf("%v", args)))
-
-		client, err := client.NewIncusClient()
-		if err != nil {
-			slog.Error(err.Error())
-		}
-		client.WithProject(app.GetProject())
-
-		vol, err := client.ShowStorageVolume(vol.Pool, vol.Name(app.Name, service, volName))
+		vol, err := app.showVolume(vol.Name(app.Name, service, volName), *vol)
 		if err != nil {
 			slog.Error(err.Error())
 		}
 		fmt.Println(vol)
-
-		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
In this PR I implemented the support for checking if the required action on instance/volume/bind was already made and allowed it to proceed further without raising an error, but reporting that the requested action was completed.