### PR TITLE
feat: support for secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 incus-compose
 dist/
+.secrets

--- a/pkg/application/adapter.go
+++ b/pkg/application/adapter.go
@@ -49,6 +49,13 @@ func BuildDirect(p *types.Project, conf *cliconfig.Config) (*Compose, error) {
 		compose.Services[s.Name] = service
 	}
 
+	// parse secretsfiles
+	compose.SecretsFiles = make(map[string]SecretsFile)
+	for _, s := range p.Secrets {
+		sf := parseSecret(s)
+		compose.SecretsFiles[s.Name] = sf
+	}
+
 	// get additional information about volumes
 	for _, vol := range p.Volumes {
 		//fmt.Println(vol.Name)
@@ -199,6 +206,13 @@ func parseService(s types.ServiceConfig) Service {
 
 	}
 
+	service.Secrets = make(map[string]Secret)
+	for _, v := range s.Secrets {
+		s := Secret{}
+		s.MountPoint = v.Target
+		service.Secrets[v.Source] = s
+	}
+
 	service.Image = s.Image
 	if s.ContainerName != "" {
 		service.ContainerName = s.ContainerName
@@ -210,4 +224,10 @@ func parseService(s types.ServiceConfig) Service {
 
 func bindNameStable(path string) string {
 	return slug.Make(path)
+}
+
+func parseSecret(s types.SecretConfig) SecretsFile {
+	sf := SecretsFile{}
+	sf.FilePath = s.File
+	return sf
 }

--- a/pkg/application/commands.go
+++ b/pkg/application/commands.go
@@ -46,6 +46,11 @@ func (app *Compose) Up() error {
 			return err
 		}
 
+		err = app.CreateSecretsForService(service)
+		if err != nil {
+			return err
+		}
+
 	}
 	return nil
 }

--- a/pkg/application/secrets.go
+++ b/pkg/application/secrets.go
@@ -1,0 +1,105 @@
+package application
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+func (app *Compose) CreateSecretsForService(service string) error {
+	slog.Info("Creating Secrets", slog.String("instance", service))
+
+	svc, ok := app.Services[service]
+	if !ok {
+		return fmt.Errorf("service %s not found", service)
+	}
+	containerName := svc.GetContainerName()
+
+	// add secrets files
+	if len(svc.Secrets) == 0 {
+		return nil
+	}
+	fmt.Println("secrets: ", svc.Secrets)
+	for k := range svc.Secrets {
+		slog.Debug("Adding Secret", slog.String("instance", service), slog.String("secret name", k))
+		secretsFileId := fmt.Sprintf("%s_%s", app.Name, k)
+
+		sf, ok := app.SecretsFiles[secretsFileId]
+		if ok {
+			// create local secret file in the /.secrets/serviceName/ directory
+			secPath := fmt.Sprintf(".secrets/%s/%s", service, k)
+			dirPath := fmt.Sprintf(".secrets/%s", service)
+
+			f, err := os.ReadFile(sf.FilePath)
+			if err != nil {
+				return err
+			}
+
+			if _, err := os.Stat(secPath); os.IsNotExist(err) {
+				if err = os.MkdirAll(dirPath, 0755); err != nil {
+					return err
+				}
+
+				err = os.WriteFile(secPath, f, 0644)
+				if err != nil {
+					return err
+				}
+
+			} else {
+				// rewrite th secret file content
+				file, err := os.Create(secPath)
+				if err != nil {
+					return err
+				}
+				defer file.Close()
+
+				if _, err = file.Write(f); err != nil {
+					return err
+				}
+
+				if err = file.Sync(); err != nil {
+					return err
+				}
+
+			}
+
+			absPath, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+			absPath = fmt.Sprintf("%s/%s", absPath, dirPath)
+			mntPath := "/run/secrets"
+			bindName := fmt.Sprintf("secrets-%s", service)
+
+			// check for existing bind
+			d, err := app.getInstanceServer(containerName)
+			if err != nil {
+				return err
+			}
+			d.UseProject(app.GetProject())
+
+			inst, _, err := d.GetInstance(containerName)
+			if err != nil {
+				return err
+			}
+
+			_, ok := inst.Devices[bindName]
+			if ok {
+				slog.Info("Device already exists", slog.String("name", bindName))
+				return nil
+			}
+
+			device := map[string]string{}
+			device["type"] = "disk"
+			device["source"] = absPath
+			device["path"] = mntPath
+
+			err = app.addDevice(service, bindName, device)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -14,6 +14,7 @@ type Compose struct {
 	ExportPath     string                      `yaml:"export_path,omitempty"`
 	Dag            graph.Graph[string, string] `yaml:"-"`
 	ComposeProject *types.Project              `yaml:"-"`
+	SecretsFiles   map[string]SecretsFile      `yaml:"secretsfiles,omitempty"`
 	conf           *config.Config
 }
 
@@ -33,6 +34,7 @@ type Service struct {
 	DependsOn             []string           `yaml:"depends_on,omitempty"`
 	InventoryGroups       []string           `yaml:"inventory_groups,omitempty"`
 	Storage               string             `yaml:"storage,omitempty"`
+	Secrets               map[string]Secret  `yaml:"secrets,omitempty"`
 }
 
 type Snapshot struct {
@@ -53,4 +55,12 @@ type Bind struct {
 	Source string `yaml:"source"`
 	Target string `yaml:"target"`
 	Shift  bool   `yaml:"shift,omitempty"`
+}
+
+type Secret struct {
+	MountPoint string `yaml:"filepath,omitempty"`
+}
+
+type SecretsFile struct {
+	FilePath string `yaml:"filepath,omitempty"`
 }


### PR DESCRIPTION
This PR implements [Issue 42](https://github.com/bketelsen/incus-compose/issues/42) for secrets support.
Secrets are mounted to the /run/secrets directory of the running container right after container is started to prevent the /run directory rewrite during the startup.
Further investigation is required to check:
1. If the delay in mounting secrets to the instance will be not too late for the programs inside the container to access them in their startup sequences.
2. If that delay would be an issue, if there is a way to mount the volumes inside the incus init sequence