### PR TITLE
fix: only create default network when it's used

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,11 @@ tasks:
     desc: build the project
     cmds:
       - go build -o incus-compose
+  install:
+    desc: install the project
+    deps: [build]
+    cmds:
+      - cp incus-compose ~/bin/
 
   sample:
     desc: Create sample incus-compose.yaml

--- a/pkg/application/network.go
+++ b/pkg/application/network.go
@@ -10,12 +10,24 @@ import (
 
 // DefaultNetworkName is the stable name of the default network for a stack
 func (c *Compose) DefaultNetworkName() string {
-	slog.Info("DefaultNetworkName", slog.String("name", c.Name+"_network"))
-	return c.Name + "_network"
+	slog.Info("DefaultNetworkName", slog.String("name", c.Name))
+	return c.Name
 }
 
 // CreateDefaultNetwork creates the default network for a stack
 func (c *Compose) CreateDefaultNetwork(nettype string) error {
+	fmt.Println(c.ComposeProject.Networks)
+	for key, network := range c.ComposeProject.Networks {
+		fmt.Println(key, network)
+		fmt.Println(network.Name)
+	}
+
+	// check to see if the Networks map has a default key
+	// if not, return
+	if _, ok := c.ComposeProject.Networks["default"]; !ok {
+		return nil
+	}
+
 	var stdinData api.NetworkPut
 	if nettype == "" {
 		nettype = "bridge"
@@ -54,7 +66,11 @@ func (c *Compose) CreateDefaultNetwork(nettype string) error {
 
 // DestroyDefaultNetwork destroys the default network for a stack
 func (c *Compose) DestroyDefaultNetwork() error {
-
+	// check to see if the Networks map has a default key
+	// if not, return
+	if _, ok := c.ComposeProject.Networks["default"]; !ok {
+		return nil
+	}
 	// Parse remote
 	resources, err := c.ParseServers(c.DefaultNetworkName())
 	if err != nil {

--- a/samples/gitea/compose.yaml
+++ b/samples/gitea/compose.yaml
@@ -1,6 +1,8 @@
 services:
   gitea:
     image: docker:gitea/gitea:latest
+    depends_on:
+      - db
     environment:
       - DB_TYPE=postgres
       - DB_HOST=db:5432

--- a/samples/network/declared/compose.yaml
+++ b/samples/network/declared/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  declared:
+    image: images:debian/bookworm/cloud
+    container_name: declared
+    restart: unless-stopped
+    networks:
+      - incusbr0
+
+
+networks:
+  incusbr0:
+    external: true

--- a/samples/network/fromprofile/compose.yaml
+++ b/samples/network/fromprofile/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  fromprofile:
+    image: images:debian/bookworm/cloud
+    container_name: fromprofile
+    restart: unless-stopped
+    x-incus-additional-profiles:
+      - br5
+
+# DOES NOT WORK


### PR DESCRIPTION
only create default network when it's used

* requires explicitly adding the default network when additional networks are specified - just like docker does