### PR TITLE
feat: labels

### DIFF
--- a/pkg/application/container.go
+++ b/pkg/application/container.go
@@ -286,6 +286,12 @@ func (app *Compose) InitContainerForService(service string) error {
 		configMap["environment."+k] = *v
 	}
 
+	for k, v := range sc.Labels {
+		configMap["user."+k] = v
+	}
+	configMap["user.dev.brian.incus-compose.directory"] = app.ComposeProject.WorkingDir
+	configMap["user.dev.brian.incus-compose"] = "true"
+
 	// add env vars from file
 	if len(sc.EnvFiles) > 0 {
 		for _, value := range sc.EnvFiles {

--- a/samples/network/declared/compose.yaml
+++ b/samples/network/declared/compose.yaml
@@ -5,6 +5,8 @@ services:
     restart: unless-stopped
     networks:
       - incusbr0
+    labels:
+      com.example.appname: my-test-app
 
 
 networks:


### PR DESCRIPTION
Adds two proprietary labels:

```
 user.dev.brian.incus-compose: "true"
  user.dev.brian.incus-compose.directory: /var/home/bjk/projects/incus/compose/samples/network/declared
```

and creates labels under `user.` for each label in the compose file.