### PR TITLE
create proxy devices for port mappings

### DIFF
--- a/pkg/application/container.go
+++ b/pkg/application/container.go
@@ -280,6 +280,22 @@ func (app *Compose) InitContainerForService(service string) error {
 		}
 	} // sc.networks
 
+	for _, port := range sc.Ports {
+		var device map[string]string
+		ip := port.HostIP
+		if ip == "" {
+			ip = "0.0.0.0"
+		}
+		name := fmt.Sprintf("docker-port-%s-%s", ip, port.Published)
+		device = map[string]string{
+			"type":    "proxy",
+			"listen":  fmt.Sprintf("%s:%s:%s", port.Protocol, ip, port.Published),
+			"connect": fmt.Sprintf("%s:%s:%d", port.Protocol, "127.0.0.1", port.Target),
+		}
+
+		devicesMap[name] = device
+	}
+
 	// config
 	configMap = map[string]string{}
 	for k, v := range sc.Environment {


### PR DESCRIPTION
I don't know if proxy devices are the best way to achieve port mapping like docker has, but I think it's a decent start at least.