### PR TITLE
feat: handle readonly flag for bind mount config

### DIFF
--- a/pkg/application/adapter.go
+++ b/pkg/application/adapter.go
@@ -192,6 +192,7 @@ func parseService(s types.ServiceConfig) Service {
 			bind.Target = v.Target
 			bind.Type = "disk"
 			bind.ReadOnly = v.ReadOnly
+			
 			for key, val := range v.Extensions {
 				switch key {
 				case "x-incus-shift":

--- a/pkg/application/adapter.go
+++ b/pkg/application/adapter.go
@@ -191,6 +191,7 @@ func parseService(s types.ServiceConfig) Service {
 			bind.Source = v.Source
 			bind.Target = v.Target
 			bind.Type = "disk"
+			bind.ReadOnly = v.ReadOnly
 			for key, val := range v.Extensions {
 				switch key {
 				case "x-incus-shift":

--- a/pkg/application/binds.go
+++ b/pkg/application/binds.go
@@ -27,6 +27,9 @@ func (app *Compose) CreateBindsForService(service string) error {
 		if bind.Shift {
 			device["shift"] = "true"
 		}
+		if bind.ReadOnly {
+			device["readonly"] = "true"
+		}
 
 		// check for existing bind
 		d, err := app.getInstanceServer(containerName)

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -51,10 +51,11 @@ type Volume struct {
 }
 
 type Bind struct {
-	Type   string `yaml:"type"`
-	Source string `yaml:"source"`
-	Target string `yaml:"target"`
-	Shift  bool   `yaml:"shift,omitempty"`
+	Type     string `yaml:"type"`
+	Source   string `yaml:"source"`
+	Target   string `yaml:"target"`
+	Shift    bool   `yaml:"shift,omitempty"`
+	ReadOnly bool   `yaml:"readonly,omitempty"`
 }
 
 type Secret struct {


### PR DESCRIPTION
A bind mount can be defined as *readonly* in the docker-compose.yml. With this commit the flag is transferred to the incus disk-device config.