### PR TITLE
Add Nix package

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,8 +95,8 @@ var rootCmd = &cobra.Command{
 			cmd.SetLogLevel(slog.LevelDebug)
 			cmd.Logger.Debug("Debug logging enabled")
 		}
-		// skip all the rest for documentation generation
-		if cmd.Name() == "gendocs" {
+		// skip all the rest for documentation generation and shell completion
+		if cmd.Name() == "gendocs" || cmd.Name() == "completion" || (cmd.Parent() != nil && cmd.Parent().Name() == "completion") {
 			return nil
 		}
 		// Figure out the config directory and config path

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+  in {
+    packages = forAllSystems (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        incus-compose = pkgs.callPackage ./nix/package.nix {};
+        default = self.packages.${system}.incus-compose;
+      }
+    );
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGo123Module,
+  installShellFiles,
+}:
+buildGo123Module rec {
+  pname = "incus-compose";
+  version = "latest";
+
+  src = ./..;
+
+  vendorHash = "sha256-QpydtvU/y+FWiWHbzIwryrPH0FMnjROEKjR9IYwxnLo=";
+  subPackages = ["."];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd incus-compose \
+      --bash <($out/bin/incus-compose completion bash) \
+      --fish <($out/bin/incus-compose completion fish) \
+      --zsh <($out/bin/incus-compose completion zsh)
+  '';
+
+  ldflags = [
+    "-X github.com/bketelsen/incus-compose/cmd.version=${version}"
+  ];
+
+  meta = with lib; {
+    description = "The missing equivalent for docker-compose in the Incus ecosystem";
+    homepage = "https://github.com/bketelsen/incus-compose";
+    license = licenses.mit;
+    mainProgram = "incus-compose";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Added Nix package and made shell completion generation work without needing a `compose.yaml` file present. This makes it easier for Nix users to use this tool and allows for generation of completions from any directory.